### PR TITLE
fix pragma for nim 2

### DIFF
--- a/quicktest.nim
+++ b/quicktest.nim
@@ -2,7 +2,7 @@ import macros, breeze, unittest
 import strutils, sequtils, strformat, tables, intsets, sets, future, json
 
 type
-  QuickRNG* = ref object {.inheritable.}
+  QuickRNG* {.inheritable.} = ref object
     seed*: int64
 
 method randomize*(rng: QuickRNG, seed: int64) {.base.} =
@@ -571,7 +571,7 @@ type
   Arbitrary*[T] = concept a
     arbitrary(type a) is Gen[T]
 
-  Gen*[T] = ref object {.inheritable.}
+  Gen*[T] {.inheritable.} = ref object
     last*: T
     fil*: FilterMixin[T]
 


### PR DESCRIPTION
This fixes the following error when compiling with Nim 2.0.4 due to
the pragma location:

    > nim c base.nim
    nim-quicktest/quicktest.nim(5, 26) Error: invalid indentation
